### PR TITLE
Rewrite papers paragraph-by-paragraph

### DIFF
--- a/AI_ACCESS.md
+++ b/AI_ACCESS.md
@@ -41,7 +41,7 @@ You're added to our shared Google Cloud project (`auc-text-mining-antithesis`) a
    )
    
    r = client.models.generate_content(
-       model="gemini-3-flash",
+       model="gemini-2.5-flash",
        contents="Reply with exactly: HELLO",
    )
    
@@ -53,6 +53,6 @@ You're added to our shared Google Cloud project (`auc-text-mining-antithesis`) a
 ## Notes
 
 - All calls bill against our shared 100 euro trial credits, so don't loop on huge inputs without telling the group.
-- Use `gemini-3-flash` for bulk runs, `gemini-3-pro` only for prompt design / QC.
+- Use `gemini-2.5-flash` for bulk runs, `gemini-2.5-pro` only for prompt design / QC.
 - Region is `europe-west4` (closest to NL).
 - No API keys needed, auth is via your Google login.

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Final Deadline - May 22
 - **[AI_ACCESS.md](https://github.com/wohoef/text_mining/blob/main/AI_ACCESS.md)**: Setup guide for calling Gemini through our shared Google Cloud project.
 - **[fetch_articles.py](https://github.com/wohoef/text_mining/blob/main/fetch_articles.py)**: Python script to automatically download PubMed articles as .txt using the API.
 - **[main.ipynb](https://github.com/wohoef/text_mining/blob/main/main.ipynb)**: Main notebook where the logistic regression model will be trained on the corresponding text features. The data is first prepped, model is trained, and then results are displayed as a confusion matrix. This is the main file where edits will happen when the model becomes more complex.
-- **[methodology_notes.md](https://github.com/wohoef/text_mining/blob/main/methodology_notes.md)**:
-- **[requirements.txt](https://github.com/wohoef/text_mining/blob/main/requirements.txt)**:
-- **[rewrite_papers.py](https://github.com/wohoef/text_mining/blob/main/rewrite_papers.py)**: 
+- **[methodology_notes.md](https://github.com/wohoef/text_mining/blob/main/methodology_notes.md)**: Notes on the corpus construction approach, alternatives we considered, and limitations of the chosen setup.
+- **[requirements.txt](https://github.com/wohoef/text_mining/blob/main/requirements.txt)**: Python dependencies required to run the code.
+- **[rewrite_papers.py](https://github.com/wohoef/text_mining/blob/main/rewrite_papers.py)**: Python script that uses the Gemini API to rewrite each human paper paragraph-by-paragraph, producing the AI dataset.
 - **[text_features.py](https://github.com/wohoef/text_mining/blob/main/text_features.py)**: Python script that contains the features that will be extracted from every article. Right now, there are only some basic features for testing purposes, but this will be edited soon to contain more complex and novel features.
-- **[ai_articles](https://github.com/wohoef/text_mining/tree/main/ai_articles)**:
-- **[human_articles](https://github.com/wohoef/text_mining/tree/main/human_articles)**:
+- **[ai_articles](https://github.com/wohoef/text_mining/tree/main/ai_articles)**: Folder containing the AI-generated papers, one .txt file per paper. Output of rewrite_papers.py.
+- **[human_articles](https://github.com/wohoef/text_mining/tree/main/human_articles)**: Folder containing the human-written PubMed papers, one .txt file per paper. Output of fetch_articles.py.
 

--- a/rewrite_papers.py
+++ b/rewrite_papers.py
@@ -1,11 +1,12 @@
-"""Rewrite a directory of academic papers with Gemini, paper-by-paper.
+"""Rewrite a directory of academic papers with Gemini, paragraph-by-paragraph.
 
 Usage:
     python rewrite_papers.py --input-dir papers/human --output-dir papers/ai
 
-Each `*.txt` in `--input-dir` is sent to the model in one call, and the
-rewrite is written to a same-named file under `--output-dir`. Files that
-already have an output are skipped, so the script is resumable.
+Each paragraph is rewritten with the full paper passed as context, with a
+per-paragraph word-count target and a one-shot retry if the rewrite is too
+short. Files that already have an output are skipped, so the script is
+resumable.
 """
 
 from __future__ import annotations
@@ -26,28 +27,44 @@ LOCATION = "europe-west4"
 DEFAULT_MODEL = "gemini-2.5-flash"
 
 PROMPT = (
-    "Rewrite the academic paper below. Do not simply swap synonyms paragraph-by-paragraph; "
-    "instead, absorb the information and restructure the sentences and flow using your "
-    "natural, highly structured academic voice. \n"
-    "Constraints:\n"
-    "- Capture all data points, arguments, and nuances without omitting scientific details.\n"
-    "- Ensure the final word count is approximately equal to the original.\n"
-    "- Output plain text only, no markdown.\n\n"
-    "Original:\n\n{text}\n\nRewrite:"
+    "Rewrite the paragraph below from an academic paper. Restructure the sentences "
+    "and reorder the information; don't just swap synonyms. Don't introduce facts "
+    "not in the original. Output plain text, target ~{target_words} words.\n\n"
+    "Full paper for context:\n{full_paper}\n\n"
+    "Paragraph:\n{paragraph}\n\n"
+    "Rewrite:"
 )
 
 
-def rewrite_one(client: genai.Client, model: str, text: str) -> str:
-    response = client.models.generate_content(
-        model=model,
-        contents=PROMPT.format(text=text),
+def _call(client, model, prompt):
+    resp = client.models.generate_content(
+        model=model, contents=prompt,
         config=types.GenerateContentConfig(
-            temperature=0.0,
-            max_output_tokens=65536,
+            temperature=0.4, max_output_tokens=2048,
             thinking_config=types.ThinkingConfig(thinking_budget=0),
         ),
     )
-    return response.text or ""
+    return resp.text or ""
+
+
+def split_paragraphs(text):
+    abstract, _, body = text.partition("\n\n")
+    return [abstract] + [p for p in body.split("\n") if p.strip()]
+
+
+def rewrite_paragraph(client, model, full_paper, paragraph):
+    target = len(paragraph.split())
+    prompt = PROMPT.format(target_words=target, full_paper=full_paper, paragraph=paragraph)
+    text = _call(client, model, prompt)
+    if len(text.split()) < 0.85 * target:
+        text = _call(client, model, prompt + f"\n\nToo short, aim for ~{target} words.")
+    return " ".join(text.split())
+
+
+def rewrite_paper(client, model, text):
+    paras = split_paragraphs(text)
+    out = [rewrite_paragraph(client, model, text, p) for p in paras]
+    return out[0] + "\n\n" + "\n".join(out[1:])
 
 
 def main() -> int:
@@ -85,7 +102,7 @@ def main() -> int:
         print(f"rewriting {path.name} ({len(text)} chars)...", end=" ", flush=True)
         start = time.time()
         try:
-            rewrite = rewrite_one(client, args.model, text)
+            rewrite = rewrite_paper(client, args.model, text)
         except Exception as exc:
             print(f"FAILED: {exc}")
             continue
@@ -102,8 +119,8 @@ def main() -> int:
             "model": args.model,
             "project": PROJECT,
             "location": LOCATION,
-            "temperature": 0.0,
-            "max_output_tokens": 65536,
+            "temperature": 0.4,
+            "max_output_tokens": 2048,
             "thinking_budget": 0,
             "prompt": PROMPT,
             "input_dir": str(args.input_dir),


### PR DESCRIPTION
Closes #12.

Splits each paper into paragraphs and rewrites each one with the full paper as context, with a per-paragraph word-count target and a one-shot retry on short outputs. Bumped temperature from 0.0 to 0.4 so the model has room to restructure instead of just swapping synonyms.

Length match on the two existing samples:
- PMC13133593: 56% -> 89%
- PMC13133595: 73% -> 95%

Also fixes the wrong model name in AI_ACCESS.md (gemini-3-flash -> gemini-2.5-flash) and fills the empty README documentation bullets for my files.